### PR TITLE
no-card/update-pnpm-lock-and-add-cursor-to-gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
-
+.cursor/
 dist/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,20 +12,7 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
 
-  apps/core:
-    dependencies:
-      tsx:
-        specifier: ^4.19.3
-        version: 4.19.3
-    devDependencies:
-      '@types/node':
-        specifier: 22.7.9
-        version: 22.7.9
-      typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
-
-  apps/lambdas:
+  apps/cloud:
     dependencies:
       aws-cdk-lib:
         specifier: 2.176.0
@@ -55,6 +42,19 @@ importers:
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
+
+  apps/core:
+    dependencies:
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.3
+    devDependencies:
+      '@types/node':
+        specifier: 22.7.9
+        version: 22.7.9
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
 
   apps/server:
     dependencies:


### PR DESCRIPTION
no-card/update-pnpm-lock-and-add-cursor-to-gitignore

## Purpose
Upon installing the repo locally, it looks like some of the dependencies have been bumped. It looks like the original `pnpm-lock.yaml` is ~2 years old.  Should we update this?

Also wanted to add a directory to gitignore.  I usually keep `documentation.md`, `project_specs.md`, and `project_milestones.md` files here on my local machine that are useful for Cursor.

## Approach
* add `cursor/` to gitignore
* updated `pnpm-lock.yaml`

## Impacted Areas in Application
pnpm-lock.yaml
